### PR TITLE
redeploy task: ops reorder to fix bug

### DIFF
--- a/tasks/cf/redeploy/task.sh
+++ b/tasks/cf/redeploy/task.sh
@@ -132,6 +132,15 @@ function cf::deploy() {
       "${PWD}/operations/disable-dynamic-asgs.yml" \
     )
 
+    if [[ -n "${ADD_CFLINUXFS4_STACK}" ]]; then
+      operations+=(
+        "${TASKDIR}/operations/use-dev-release-capi.yml" \
+        "${TASKDIR}/operations/cflinuxfs4-rootfs-certs.yml" \
+        "${TMPDIR}/add-cflinuxfs4.yml"
+      )
+      util::print::info "[task] * added cflinuxfs4 opsfiles to deploy command"
+    fi
+
     if [[ -n "${DEPLOY_WINDOWS_CELL}" ]]; then
       operations+=(
         "${PWD}/operations/windows2019-cell.yml" \
@@ -145,15 +154,6 @@ function cf::deploy() {
       operations+=(
         "${TASKDIR}/operations/scale-api-and-diego-cells.yml"
       )
-    fi
-
-    if [[ -n "${ADD_CFLINUXFS4_STACK}" ]]; then
-      operations+=(
-        "${TASKDIR}/operations/use-dev-release-capi.yml" \
-        "${TASKDIR}/operations/cflinuxfs4-rootfs-certs.yml" \
-        "${TMPDIR}/add-cflinuxfs4.yml"
-      )
-      util::print::info "[task] * added cflinuxfs4 opsfiles to deploy command"
     fi
 
     arguments=()


### PR DESCRIPTION
Previously, when DEPLOY_WINDOWS_CELL and ADD_CFLINUXFS4_STACK are used together, the add-cflinuxfs4.yml opsfile would overwrite the cc/stacks property set by the windows opsfile to just {cflinuxfs3,fs4} thereby removing {windows, windows2016}.

By using the addition opsfile after the overwriting ops file, we can deploy with all 4 stacks together.

Fixes: https://buildpacks.ci.cf-app.com/teams/main/pipelines/binary-buildpack/jobs/specs-edge-brats-develop/builds/471#L634a020c:72

Note: We can use cf-d cflinuxfs4 ops file directly now, but that's for another day.