### PR TITLE
redeploy: update task image

### DIFF
--- a/tasks/cf/redeploy/task.yml
+++ b/tasks/cf/redeploy/task.yml
@@ -5,7 +5,7 @@ image_resource:
   type: registry-image
   source:
     repository: cfbuildpacks/ci
-    tag: bbl-8.4
+    tag: latest
 
 inputs:
   - name: ci


### PR DESCRIPTION
It looks like newer toolsmith env doesn't let older versions of bosh cli talk to it
(https://buildpacks.ci.cf-app.com/teams/main/pipelines/staticfile-buildpack/jobs/specs-edge-integration-develop-cflinuxfs3/builds/32#L63de325b:10)

This change makes use of recent update of tools in the cfbuildpacks/ci:latest image.
See https://github.com/cloudfoundry/buildpacks-ci/commits/971227906b074a30720efa4b9f08b7f9fb90c68a/Dockerfile